### PR TITLE
Add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Default reviewers for all changes in entire repository,
+# unless a later match takes precedence
+*  @ricardosalveti @ndechesne


### PR DESCRIPTION
Add initial CODEOWNERS, to be extended as we add more contributions and maintainers.