### PR TITLE
ci: initial build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,9 @@ jobs:
       - name: Build QLI
         run: |
           cd QLI
+          # FIXME: apply_poky_patches() fails in setup-environment and it's not
+          # needed, so skip it for now, until it's fixed properly.
+          sed -i '/    apply_poky_patches/d' setup-environment
           MACHINE=${{ matrix.machine }} DISTRO=qcom-wayland QCOM_SELECTED_BSP=${{ matrix.bsp }} source setup-environment
           bitbake-layers add-layer $GITHUB_WORKSPACE
           bitbake qcom-console-image

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,60 @@
+name: Build Qualcomm Linux
+
+on:
+  workflow_call:
+
+env:
+  CACHE_DIR: /srv/gh-runners/quic-yocto/3rdparty
+  BASE_ARTIFACT_URL: "https://quic-yocto-fileserver-1029608027416.us-central1.run.app/${{ github.run_id }}"
+  MANIFEST_URL: https://github.com/quic-yocto/qcom-manifest
+  MANIFEST_BRANCH: qcom-linux-scarthgap
+  QLI_VERSION: QLI.1.4
+
+jobs:
+  build:
+    if: github.repository == 'qualcomm-linux/meta-qcom-3rdparty'
+    strategy:
+      fail-fast: true
+      matrix:
+        machine:
+          - qcs6490-rb3gen2-core-kit
+          - qcs6490-rb3gen2-vision-kit
+          - qcs9075-ride-sx
+          - qcs9075-rb8-core-kit
+          - qcs9100-ride-sx
+          - qcs8300-ride-sx
+        bsp:
+          - custom
+        include:
+          - machine: qcs9100-ride-sx
+            bsp: base
+          - machine: qcs8300-ride-sx
+            bsp: base
+    runs-on: [self-hosted, x86]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get manifest file
+        run: |
+          git clone --depth=1 ${MANIFEST_URL} -b ${MANIFEST_BRANCH}
+          cd qcom-manifest
+          MANIFEST_FILE=$(ls *${QLI_VERSION}*.xml | sort | grep -v -e realtime-linux -e qim-product-sdk -e robotics-product-sdk | tail -1)
+          echo "Manifest file: ${MANIFEST_FILE}"
+          echo "MANIFEST_FILE=${MANIFEST_FILE}" >> "$GITHUB_ENV"
+
+      - name: Setup workspace
+        run: |
+          mkdir QLI
+          cd QLI
+          repo init -u ${MANIFEST_URL} -b ${MANIFEST_BRANCH} -m ${MANIFEST_FILE}
+          repo sync
+          mkdir -p ${CACHE_DIR}/{downloads,sstate-cache}
+          ln -s ${CACHE_DIR}/downloads
+          ln -s ${CACHE_DIR}/sstate-cache
+
+      - name: Build QLI
+        run: |
+          cd QLI
+          MACHINE=${{ matrix.machine }} DISTRO=qcom-wayland QCOM_SELECTED_BSP=${{ matrix.bsp }} source setup-environment
+          bitbake-layers add-layer $GITHUB_WORKSPACE
+          bitbake qcom-console-image

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,9 @@
+name: Build on PR
+
+on:
+  pull_request:
+
+jobs:
+  build-pr:
+    uses: ./.github/workflows/build.yml
+

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,10 @@
+name: Build on push
+
+on:
+  push:
+    branches:
+      - kirkstone
+
+jobs:
+  build:
+    uses: ./.github/workflows/build.yml


### PR DESCRIPTION
This is an initial workflow to build the QLI 1.x (scarthgap) branch along with meta-qcom-3rdparty.

This is using a specific persistent folder, to avoid mixing sstate and downloads between QLI 1.x and QLI mainline.

This initial workflow builds all valid combinations based on the QLI 1.4 release notes. E.g.
 - DISTRO=qcom-wayland
 - QCOM_SELECTED_BSP=custom for all machines
 - QCOM_SELECTED_BSP=base for a subset of the machines And only builds the qcom-console-image.

This initial workflow only builds the regular manifest. Realtime, robotics or MM SDKs will be added later.

meta-qcom-3rdparty is added to the Yocto build configuration.