### PR TITLE
ci: update ci fragments to align with meta-qcom expectations

### DIFF
--- a/ci/ci.yml
+++ b/ci/ci.yml
@@ -1,0 +1,8 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+  includes:
+    - ci/meta-qcom.yml
+    - repo: meta-qcom
+      file: ci/ci.yml

--- a/ci/meta-qcom.yml
+++ b/ci/meta-qcom.yml
@@ -1,0 +1,9 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/siemens/kas/master/kas/schema-kas.json
+
+header:
+  version: 14
+
+repos:
+  meta-qcom:
+    url: https://github.com/qualcomm-linux/meta-qcom
+    branch: master

--- a/ci/mirror.yml
+++ b/ci/mirror.yml
@@ -3,10 +3,6 @@
 header:
   version: 14
   includes:
+    - ci/meta-qcom.yml
     - repo: meta-qcom
       file: ci/mirror.yml
-
-repos:
-  meta-qcom:
-    url: https://github.com/qualcomm-linux/meta-qcom
-    branch: master

--- a/ci/qcom-distro.yml
+++ b/ci/qcom-distro.yml
@@ -3,10 +3,6 @@
 header:
   version: 14
   includes:
+    - ci/meta-qcom.yml
     - repo: meta-qcom
       file: ci/qcom-distro.yml
-
-repos:
-  meta-qcom:
-    url: https://github.com/qualcomm-linux/meta-qcom
-    branch: master


### PR DESCRIPTION
ci.yml is required by the compile action (provided by meta-qcom).

Also bring meta-qcom.yml as done in meta-qcom-distro to simplify the fragments available locally.