### PR TITLE
workflows/build: fix the distro name

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -97,7 +97,7 @@ jobs:
         machine:
           - uno-q
         distro:
-          - name: poky-altcfg
+          - name: nodistro
             yamlfile: ""
           - name: qcom-distro
             yamlfile: ':ci/qcom-distro.yml'


### PR DESCRIPTION
Currently, the default distribution for oe-core is the nodistro.