### PR TITLE
ci: update actions/checkout to v6

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -34,7 +34,9 @@ jobs:
           wget -qO ${KAS_CONTAINER} https://raw.githubusercontent.com/siemens/kas/refs/tags/$LATEST/kas-container
           chmod +x ${KAS_CONTAINER}
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Run kas lock
         run: |
@@ -57,7 +59,9 @@ jobs:
     if: github.repository_owner == 'qualcomm-linux'
     runs-on: [self-hosted, qcom-u2404, amd64]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Download kas lockfile
         uses: actions/download-artifact@v7
@@ -116,7 +120,9 @@ jobs:
                 yamlfile: ":ci/linux-qcom-next.yml"
     name: ${{ matrix.machine }}/${{ matrix.distro.name }}${{ matrix.kernel.dirname }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Run kas build
         uses: qualcomm-linux/meta-qcom/.github/actions/compile@master

--- a/.github/workflows/repolinter.yml
+++ b/.github/workflows/repolinter.yml
@@ -13,7 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
       - name: Verify repolinter config file is present
         id: check_files
         uses: andstor/file-existence-action@v3


### PR DESCRIPTION
Mirror actions/checkout update as done in meta-qcom [1].

[1]
https://github.com/qualcomm-linux/meta-qcom/commit/96f6ccfdd49be8d0e5bcfc3a3deaf7214899aa3c