### PR TITLE
iris-video-dlkm: downgrade uno-q to 1.0.4

### DIFF
--- a/recipes-kernel/iris-video-module/iris-video-dlkm_%.bbappend
+++ b/recipes-kernel/iris-video-module/iris-video-dlkm_%.bbappend
@@ -1,0 +1,4 @@
+# This driver is not expected to support/work on agatti (the soc on unoq).
+# However, this hash is buildable, which allows maintaining a sane ci.
+SRCREV:uno-q  = "02248f4021f7690e675c408b4fd0208ad559a1d5"
+PV:uno-q = "1.0.4"


### PR DESCRIPTION
The iris-video-dlkm is currently broken with the uno-q kernel.

Fixes https://github.com/qualcomm-linux/meta-qcom-3rdparty/issues/35