### PR TITLE
ci: add meta-arm fragment importing from meta-qcom

### DIFF
--- a/ci/meta-arm.yml
+++ b/ci/meta-arm.yml
@@ -1,0 +1,6 @@
+header:
+  version: 14
+  includes:
+    - ci/meta-qcom.yml
+    - repo: meta-qcom
+      file: ci/meta-arm.yml


### PR DESCRIPTION
meta-arm is referenced by build-yocto which is reused from meta-qcom, so include a kas fragment which references the content from the same fragment also available in meta-qcom.

This is done in order to make CI compatible with the meta-qcom build-yocto workflow.