### PR TITLE
ci: build-yocto: drop update from kas lock

### DIFF
--- a/.github/workflows/build-yocto.yml
+++ b/.github/workflows/build-yocto.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Run kas lock
         run: |
-          ${KAS_CONTAINER} lock --update ci/base.yml:ci/qcom-distro.yml
+          ${KAS_CONTAINER} lock ci/base.yml:ci/qcom-distro.yml
 
       - name: Upload kas lockfile
         uses: actions/upload-artifact@v6


### PR DESCRIPTION
With the removal of KAS_REPO_REF_DIR (meta-qcom commit a581d6afa98a), there is no longer a need to call 'kas lock' with --update. On a clean checkout, plain 'kas lock' behaves equivalently, generating a complete lock file without unnecessarily updating repositories.