### PR TITLE
Enable markdown linter workflow action + address linting issues

### DIFF
--- a/.github/.markdownlint.yaml
+++ b/.github/.markdownlint.yaml
@@ -1,0 +1,15 @@
+# markdownlint configuration
+# https://github.com/DavidAnson/markdownlint
+
+# MD013 - Line length
+MD013: false
+
+# MD024 - Multiple headings with the same content
+MD024:
+  siblings_only: true
+
+# MD033 - Inline HTML
+MD033: false
+
+# MD041 - First line in a file should be a top-level heading
+MD041: true

--- a/.github/workflows/markdownlint.yml
+++ b/.github/workflows/markdownlint.yml
@@ -1,0 +1,25 @@
+name: Markdown Lint
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '**/*.md'
+      - '.github/.markdownlint.yaml'
+  pull_request:
+    paths:
+      - '**/*.md'
+      - '.github/.markdownlint.yaml'
+
+jobs:
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v6
+
+      - name: Run markdownlint
+        uses: DavidAnson/markdownlint-cli2-action@6b51ade7a9e4a75a7ad929842dd298a3804ebe8b # v23.1.0
+        with:
+          config: '.github/.markdownlint.yaml'
+          globs: '**/*.md'

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -3,9 +3,8 @@ name: Build on PR
 on:
   pull_request:
     paths-ignore:
-      - 'README.md'
-      - 'README'
-      - 'SECURITY.md'
+      - '**/*.md'
+      - '.github/.markdownlint.yaml'
 
 permissions:
   checks: write

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ platforms.
 
 This layers provides additional recipes and machine configuration files for
 Third-Party Maintained Qualcomm platforms. Reference boards that are officially
-supported by Qualcomm are available via ``meta-qcom`` instead.
+supported by Qualcomm are available via `meta-qcom` instead.
 
 This layer depends on:
 
-```
+```text
 URI: https://github.com/openembedded/openembedded-core.git
 layers: meta
 branch: master
@@ -23,7 +23,6 @@ revision: HEAD
 URI: https://github.com/qualcomm-linux/meta-qcom.git
 branch: master
 revision: HEAD
-
 ```
 
 ## Branches
@@ -55,8 +54,8 @@ Pull requests will be discussed within the GitHub pull-request infrastructure.
 
 ## Maintainer(s)
 
-* Ricardo Salveti <ricardo.salveti@oss.qualcomm.com>
-* Nicolas Dechesne <nicolas.dechesne@oss.qualcomm.com>
+- Ricardo Salveti <ricardo.salveti@oss.qualcomm.com>
+- Nicolas Dechesne <nicolas.dechesne@oss.qualcomm.com>
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 OpenEmbedded/Yocto Project BSP layer for Third-Party Maintained Qualcomm based
 platforms.
 
-This layers provides additional recipes and machine configuration files for
+This layer provides additional recipes and machine configuration files for
 Third-Party Maintained Qualcomm platforms. Reference boards that are officially
 supported by Qualcomm are available via `meta-qcom` instead.
 
@@ -60,4 +60,4 @@ Pull requests will be discussed within the GitHub pull-request infrastructure.
 ## License
 
 This layer is licensed under the MIT license. Check out [COPYING.MIT](COPYING.MIT)
-for more detais.
+for more details.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -17,5 +17,5 @@ affected, the recipe and its version, and any example code, if available.
 Branches maintained with security fixes
 ---------------------------------------
 
-See https://wiki.yoctoproject.org/wiki/Releases for the list of current
+See <https://wiki.yoctoproject.org/wiki/Releases> for the list of current
 releases. We only accept patches for the LTS releases and the main branch.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -9,13 +9,14 @@ It follows the same conventions used by the Yocto Project and OpenEmbedded upstr
 
 The `meta-qcom-3rdparty` layer provides a **common OpenEmbedded / Yocto BSP** foundation for third-party hardware platforms based on Qualcomm SoCs.
 
-**Goals**
+### Goals
 
 - **Common layer for non-Qualcomm EVKs:** consolidate enablement for boards not officially maintained by Qualcomm.
 - **Clean BSP implementation:** a shared source of truth that vendors can reuse without divergence.
 - **Extend the Qualcomm Linux ecosystem:** encourage community participation and long-term maintainability aligned with `meta-qcom`.
 
 References:
+
 - [Yocto Project Overview](https://docs.yoctoproject.org/overview-manual/yp-intro.html)
 - [OpenEmbedded Layer Index](https://layers.openembedded.org/layerindex/)
 
@@ -41,6 +42,7 @@ Our process mirrors the official Yocto Project contribution flow — see
 ### 2.2  Machine-Specific Isolation
 
 Because this layer expects to host multiple vendor platforms:
+
 - Use **machine overrides** (`:machine` or `:append:machine`) to confine board-specific logic.
 - Avoid cross-contamination between machines or with upstream `meta-qcom`.
 - Do not introduce SoC-generic behavior under a machine-specific path. Those SoC-generic behavior must be sent/upstreamed to `meta-qcom` instead.
@@ -50,6 +52,7 @@ Reference: [BitBake Overrides](https://docs.yoctoproject.org/ref-manual/variable
 ### 2.3  Repository Organization
 
 All vendor boards live together in a single layer:
+
 - **No branch or folder segregation per vendor.**
 - Maintain quality equivalent to `meta-qcom`.
 
@@ -67,6 +70,7 @@ Reference: [Understanding bbappends](https://docs.yoctoproject.org/ref-manual/te
 - Avoid distribution-specific logic — vendors may ship separate distro layers.
 
 Preferred test distros:
+
 - `nodistro` (systemd-compatible)
 - [`meta-qcom-distro`](https://github.com/qualcomm-linux/meta-qcom-distro)
 
@@ -155,36 +159,49 @@ Every machine must have a configuration file under `conf/machine/`.
 Key elements to include:
 
 - **SoC include** — pull in the common SoC baseline from `meta-qcom`:
+
   ```bitbake
   require conf/machine/include/qcom-qcm2290.inc
   ```
+
 - **Vendor override** — prepend a vendor-scoped override so that vendor-specific
   appends can use it without affecting other machines:
+
   ```bitbake
   MACHINEOVERRIDES =. "arduino:"
   ```
+
 - **Kernel provider** — point to the board-specific kernel recipe:
+
   ```bitbake
   PREFERRED_PROVIDER_virtual/kernel ?= "linux-arduino"
   ```
+
 - **Device tree** — declare the DTB name(s) used at build and boot time:
+
   ```bitbake
   QCOM_DTB_DEFAULT ?= "qrb2210-arduino-imola"
   KERNEL_DEVICETREE ?= "qcom/qrb2210-arduino-imola.dtb"
   ```
+
 - **Machine features** — list hardware capabilities:
+
   ```bitbake
   MACHINE_FEATURES = "efi usbhost usbgadget alsa wifi bluetooth"
   ```
+
 - **Packagegroups** — pull in board firmware and DSP binaries at image level:
+
   ```bitbake
   MACHINE_ESSENTIAL_EXTRA_RRECOMMENDS += " \
       packagegroup-uno-q-firmware \
       packagegroup-uno-q-hexagon-dsp-binaries \
   "
   ```
+
 - **Boot and partition paths** — align with the layout expected by `qcom-common`
   image helpers:
+
   ```bitbake
   QCOM_BOOT_FILES_SUBDIR = "qrb2210-arduino-imola"
   QCOM_PARTITION_FILES_SUBDIR ?= "partitions/qrb2210-unoq/emmc-16GB"
@@ -285,7 +302,7 @@ matrix:
 When adding a new board, ensure the following files are present:
 
 | File | Purpose |
-|---|---|
+| --- | --- |
 | `conf/machine/<machine>.conf` | Machine definition |
 | `recipes-bsp/packagegroups/packagegroup-<machine>.bb` | Firmware + DSP packagegroup |
 | `recipes-bsp/firmware-boot/firmware-qcom-boot-<soc>-<board>_<ver>.bb` | Boot firmware recipe |

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -45,7 +45,7 @@ Because this layer expects to host multiple vendor platforms:
 
 - Use **machine overrides** (`:machine` or `:append:machine`) to confine board-specific logic.
 - Avoid cross-contamination between machines or with upstream `meta-qcom`.
-- Do not introduce SoC-generic behavior under a machine-specific path. Those SoC-generic behavior must be sent/upstreamed to `meta-qcom` instead.
+- Do not introduce SoC-generic behavior under a machine-specific path. Such SoC-generic behavior must be sent/upstreamed to `meta-qcom` instead.
 
 Reference: [BitBake Overrides](https://docs.yoctoproject.org/ref-manual/variables.html#var-OVERRIDES)
 


### PR DESCRIPTION
- Add markdownlint configuration and GitHub Actions CI workflow to enforce
  consistent markdown style on push/PR
- Fix lint violations: add language specifiers to fenced code blocks, use
  consistent dash style for unordered lists, wrap bare URLs, and add blank
  lines around lists and fenced code blocks
- Convert emphasis-as-heading to a proper heading and normalize table
  separator column style in `docs/contributing.md`
- Fix typos in README.md ("This layers" -> "This layer", "detais" -> "details")
- Fix subject-verb agreement in `docs/contributing.md` ("Those SoC-generic
  behavior" -> "Such SoC-generic behavior")
- Update `paths-ignore` in the PR build workflow so builds are skipped for
  markdown-only changes (now covered by the standalone markdownlint workflow)