### PR TITLE
radxa-dragon-q6a: enable HDMI

### DIFF
--- a/recipes-kernel/linux/linux-qcom-next_git.bbappend
+++ b/recipes-kernel/linux/linux-qcom-next_git.bbappend
@@ -3,4 +3,6 @@ FILESEXTRAPATHS:prepend:radxa-dragon-q6a := "${THISDIR}/radxa-dragon-q6a:"
 SRC_URI:append:radxa-dragon-q6a = " \
 			file://realtek-eth-8169.cfg \
 			file://drm-simple-bridge.cfg \
+			file://0001-driver-core-seed-deferred-probe-timeout-from-kconfig.patch \
+			file://deferred-probe-timeout.cfg \
 "

--- a/recipes-kernel/linux/linux-qcom-next_git.bbappend
+++ b/recipes-kernel/linux/linux-qcom-next_git.bbappend
@@ -2,4 +2,5 @@ FILESEXTRAPATHS:prepend:radxa-dragon-q6a := "${THISDIR}/radxa-dragon-q6a:"
 
 SRC_URI:append:radxa-dragon-q6a = " \
 			file://realtek-eth-8169.cfg \
+			file://drm-simple-bridge.cfg \
 "

--- a/recipes-kernel/linux/radxa-dragon-q6a/0001-driver-core-seed-deferred-probe-timeout-from-kconfig.patch
+++ b/recipes-kernel/linux/radxa-dragon-q6a/0001-driver-core-seed-deferred-probe-timeout-from-kconfig.patch
@@ -1,0 +1,26 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Ryan Baumann <ryan.baumann@devdocs.work>
+Date: Thu, 9 Jul 2026 15:30:00 -0400
+Subject: [PATCH] driver core: seed deferred_probe_timeout from Kconfig
+
+The deferred-probe timeout initializer is hardcoded to 15 rather than seeded
+from CONFIG_DRIVER_DEFERRED_PROBE_TIMEOUT, so the Kconfig value has no effect.
+Restore the mainline behaviour of initialising it from the Kconfig symbol,
+letting a board disable or extend the timeout via kernel config.
+
+Upstream-Status: Pending
+
+Signed-off-by: Ryan Baumann <ryan.baumann@devdocs.work>
+---
+diff --git a/drivers/base/dd.c b/drivers/base/dd.c
+--- a/drivers/base/dd.c
++++ b/drivers/base/dd.c
+@@ -258,7 +258,7 @@
+ DEFINE_SHOW_ATTRIBUTE(deferred_devs);
+ 
+ #ifdef CONFIG_MODULES
+-static int driver_deferred_probe_timeout = 15;
++static int driver_deferred_probe_timeout = CONFIG_DRIVER_DEFERRED_PROBE_TIMEOUT;
+ #else
+ static int driver_deferred_probe_timeout;
+ #endif

--- a/recipes-kernel/linux/radxa-dragon-q6a/deferred-probe-timeout.cfg
+++ b/recipes-kernel/linux/radxa-dragon-q6a/deferred-probe-timeout.cfg
@@ -1,0 +1,2 @@
+# wait for the gpucc clock module (loads late) so the GPU can bind
+CONFIG_DRIVER_DEFERRED_PROBE_TIMEOUT=-1

--- a/recipes-kernel/linux/radxa-dragon-q6a/drm-simple-bridge.cfg
+++ b/recipes-kernel/linux/radxa-dragon-q6a/drm-simple-bridge.cfg
@@ -1,0 +1,2 @@
+# on-board radxa,ra620 DP-to-HDMI bridge
+CONFIG_DRM_SIMPLE_BRIDGE=m


### PR DESCRIPTION
Display output needs two changes on this board:

  - CONFIG_DRIVER_DEFERRED_PROBE_TIMEOUT=-1 (this tree hardcodes the
  deferred-probe timeout and ignores the Kconfig, so a dd.c patch restores the
  mainline wiring that seeds it) so the Adreno SMMU waits for the late-loading
  gpucc module; without it the GPU can't bind and msm tears down all of DRM (no
  /dev/dri, dark HDMI).
  - CONFIG_DRM_SIMPLE_BRIDGE re-enabled -- prune.config unsets it, but the
  on-board radxa,ra620 DP-to-HDMI bridge needs it (for HDMI).

  Confirmed on-device: /dev/dri/card0, HDMI-A-1 at 1920x1080, GPU bound.